### PR TITLE
Precache the draft-07 schema with an https URL.

### DIFF
--- a/config/config.wikimedia.yaml
+++ b/config/config.wikimedia.yaml
@@ -13,7 +13,7 @@ worker_heap_limit_mb: 250
 
 # Logger info
 logging:
-  level: info
+  level: debug
 
 #  streams:
 #  # Use gelf-stream -> logstash

--- a/lib/EventValidator.js
+++ b/lib/EventValidator.js
@@ -125,6 +125,16 @@ class EventValidator {
                 this.ajv.addMetaSchema(metaSchema);
             });
         }
+        // Both http and https can be used as the draft-07 $schema URL.
+        // However, the draft-07 metaschema uses an http URL as its
+        // $id field.  AJV caches schemas by their $id.  In order
+        // to avoid a remote lookup of this metaschema if a
+        // schema sets $schema to https, we manually cache the
+        // local copy of draft-07 metaschema with the https URL.
+        this.ajv.addSchema(
+            require('ajv/lib/refs/json-schema-draft-07.json'),
+            'https://json-schema.org/draft-07/schema'
+        );
 
         // Add a meta schema to check if schemas are secure for AJV compilation.
         this.isSchemaSecure = this.ajv.compile(secureMetaSchema);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventgate",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Event intake service - POST JSONSchemaed events, validate, and produce.",
   "main": "./app.js",
   "scripts": {


### PR DESCRIPTION
This avoids a remote lookup for draft-07 in case
$schema: https://json-schema.org/draft-07/schema is
encountered.

Change-Id: I35de1d4c76ebabd5bab52dbd01594168003bd2b4