### PR TITLE
Allow for more easily using EventGate as a dependency

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -257,11 +257,40 @@ function initAndLogRequest(req, app) {
 }
 
 
+
+/**
+ * Given module path m, this will attempt to require it
+ * with the current working directory at the end of module.paths.
+ * module.paths will be unmodified when this function returns.
+ * @param {string} m
+ * @return {any}
+ */
+function requireRelative(m) {
+    let pushedCwd = false;
+
+    if (!module.paths.includes(process.cwd())) {
+        // add cwd to the list of module search paths so that
+        // this can be used as a library with custom modules.
+        module.paths.push(process.cwd());
+        pushedCwd = true;
+    }
+    try {
+        return require(m);
+    } finally {
+        if (pushedCwd) {
+            // Now that' we've required (or failed requiring) the module,
+            // remove './' from module search paths.
+            module.paths.pop();
+        }
+    }
+}
+
 module.exports = {
     HTTPError,
     initAndLogRequest,
     wrapRouteHandlers,
     setErrorHandler,
-    router: createRouter
+    router: createRouter,
+    requireRelative
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventgate",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Event intake service - POST JSONSchemaed events, validate, and produce.",
   "main": "./app.js",
   "scripts": {
@@ -11,6 +11,9 @@
     "docker-test": "service-runner docker-test",
     "test-build": "service-runner docker-test && service-runner build --deploy-repo --force",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
+  },
+  "bin": {
+    "eventgate": "server.js"
   },
   "repository": {
     "type": "git",

--- a/routes/events.js
+++ b/routes/events.js
@@ -7,6 +7,7 @@ const _     = require('lodash');
  * The main router object
  */
 const router = sUtil.router();
+const requireRelative = sUtil.requireRelative;
 
 /**
  * The main application object reported when this module is require()d
@@ -139,7 +140,9 @@ module.exports = async(appObj) => {
         `Instantiating EventGate from ${eventGateFactoryModule}`
     );
 
-    const eventGate = await require(eventGateFactoryModule).factory(
+    // add '.' to the list of module search paths so that
+    // this can be used as a library with custom modules.
+    const eventGate = await requireRelative(eventGateFactoryModule).factory(
         app.conf, app.logger._logger, app.metrics
     );
     router.post('/events', (req, res) => {


### PR DESCRIPTION
By adding the cwd to module.paths when we require the
eventgate_factory_module, we make it possible for
a dependent repository to provide its own factory
modules from within its cwd, e.g.

  eventgate_factory_module: 'lib/my-eventgate-factory'

at path /path/to/my-dependent-project/lib/my-eventgate-factory.js.

This commit also exports an 'eventgate' bin script that
will launch service.js.

Bug: T226668
Change-Id: Ie202b9326918637eb41c165153fd7b7f1d4d7460