### PR TITLE
Allow JSON body parsing with text/plain Content-Type

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,8 +120,15 @@ function initApp(options) {
     app.set('etag', false);
     // enable compression
     app.use(compression({ level: app.conf.compression_level }));
-    // use the JSON body parser
-    app.use(bodyParser.json({ limit: app.conf.max_body_size || '100kb' }));
+    // --- BEGIN EventGate modification ---
+    // use the JSON body parser.
+    // We specify both the correct type 'application/json', as well as
+    // 'text/plain', so that browser navigator.sendBeacon calls will work.
+    // sendBeacon CORS restrictions don't allow sendBeacon to POST with an application/json
+    // content type, so we allow its default text/plain to be parsed as JSON.
+    // See: https://stackoverflow.com/a/44142982
+    app.use(bodyParser.json({ limit: app.conf.max_body_size || '100kb', type: ['application/json', 'text/plain']  }));
+    // --- END EventGate modification ---
     // use the application/x-www-form-urlencoded parser
     app.use(bodyParser.urlencoded({ extended: true }));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventgate",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Event intake service - POST JSONSchemaed events, validate, and produce.",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
We want to be able to accept POSTed events from
browser navigator.sendBeacon calls, but sendBeacon
CORS restrictions don't allow Content-Type: application/json.
sendBeacon sets Content-Type to text/plain by default; so
assume POST bodies with text/plain are JSON.

Bug: T238544
