### PR TITLE
Pass router into eventgate factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,16 @@ production via function injection.  The HTTP route that handles POSTing of event
 instantiated EventGate instance.  To make this configurable (without editing the route code), the
 route in routes/events.js will look for `app.conf.eventgate_factory_module` and require it.
 This module is expected to export a function named `factory` that takes a conf `options` object,
-a bunyan `logger`, and an optional `metrics` object that conforms to the node-statsd interface.
+a bunyan `logger`, and an optional `metrics` object that conforms to the node-statsd interface
 (This will actually be provided from
-[service-runner app metrics](https://github.com/wikimedia/service-runner#metric-reporting).
-The function should return a Promise of an instantiated EventGate.
+[service-runner app metrics](https://github.com/wikimedia/service-runner#metric-reporting), and
+the Express router used to handle the events (in case your EventGate implementation wants to
+add any extra routes at this time).  E.g.
+
+```javascript
+function myEventGateFactory(options, logger, metrics, router) { ... }
+````
+The factory function should return a Promise of an instantiated EventGate.
 
 Once the EventGate Promise resolves, the `/v1/events` HTTP route will be added and will use the
 instantiated EventGate to validate and produce incoming events.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventgate",
-  "version": "1.0.17",
+  "version": "1.1.0",
   "description": "Event intake service - POST JSONSchemaed events, validate, and produce.",
   "main": "./index.js",
   "scripts": {

--- a/routes/events.js
+++ b/routes/events.js
@@ -25,7 +25,7 @@ async function handleEvents(eventGate, conf, req, res) {
 
     // If empty body, return 400 now.
     if (_.isEmpty(req.body)) {
-        res.statusMessage = 'Request body was empty. Must provide JSON encoded events.'
+        res.statusMessage = 'Request body was empty. Must provide JSON encoded events.';
         req.logger.log('warn/events', res.statusMessage);
         res.status(400);
         res.end();

--- a/routes/events.js
+++ b/routes/events.js
@@ -25,7 +25,7 @@ async function handleEvents(eventGate, conf, req, res) {
 
     // If empty body, return 400 now.
     if (_.isEmpty(req.body)) {
-        res.statusMessage = 'Must provide JSON encoded events in request body.';
+        res.statusMessage = 'Request body was empty. Must provide JSON encoded events.'
         req.logger.log('warn/events', res.statusMessage);
         res.status(400);
         res.end();
@@ -143,7 +143,7 @@ module.exports = async(appObj) => {
     // add '.' to the list of module search paths so that
     // this can be used as a library with custom modules.
     const eventGate = await requireRelative(eventGateFactoryModule).factory(
-        app.conf, app.logger._logger, app.metrics
+        app.conf, app.logger._logger, app.metrics, router
     );
     router.post('/events', (req, res) => {
         handleEvents(eventGate, app.conf, req, res);


### PR DESCRIPTION
This will allow for custom EventGate implementations
(like eventgate-wikimedia) to register extra routes
with the eventgate service.

eventgate-wikimedia will use this to expose runtime stream
configs.

Bug: T253157
Change-Id: I72b21df3696e5fa09bf5e9597037c80af79ce6d6