### PR TITLE
Bump service-runner dependecy to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventgate",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Event intake service - POST JSONSchemaed events, validate, and produce.",
   "engines": {
     "node": ">=10.16.0"
@@ -50,7 +50,7 @@
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.11",
     "preq": "^0.5.9",
-    "service-runner": "^2.8.4",
+    "service-runner": "^3.1.0",
     "swagger-router": "^0.7.4",
     "swagger-ui-dist": "^3.22.3",
     "uuid": "^3.3.2",


### PR DESCRIPTION
Bumping eventgate-wikimedia in https://phabricator.wikimedia.org/T306181, 
wasn't enough, turns out this repo also needs a bump.

Bump version to reflect this.