### PR TITLE
Test validation of "const" keyword

### DIFF
--- a/test/features/lib/EventValidator.js
+++ b/test/features/lib/EventValidator.js
@@ -79,6 +79,16 @@ const testEvent_insecure = {
     test: 'test_value_0'
 };
 
+const testEvent_with_const = {
+    '$schema': '/test_const/0.0.1',
+    meta: {
+        stream: 'test.event',
+        id: '5e1dd101-641c-11e8-ab6c-b083fecf1287',
+    },
+	integer_const: 42,
+	string_const: "hello world"
+};
+
 function extractSchemaUri(event) {
     return event.$schema;
 }
@@ -206,5 +216,54 @@ describe('EventValidator test instance', () => {
 
         assert.deepEqual(e1, e2);
     });
+
+	it('should pass validation of valids const', async() => {
+		const event = await eventValidator.validate(testEvent_with_const);
+		assert.deepEqual(testEvent_with_const, event);
+	});
+
+	it('should fail validation on const string with wrong value', async() => {
+		var event_with_invalid_string = {...testEvent_with_const};
+		event_with_invalid_string["string_const"] = "bonjour";  // instead of "hello world"
+		try {
+			await eventValidator.validate(event_with_invalid_string);
+			assert(false, "ValidationError should have been thrown");
+		} catch (err) {
+			assert(err instanceof ValidationError);
+		}
+	});
+
+	it('should fail validation on const integer with wrong value', async() => {
+		var event_with_invalid_integer = {...testEvent_with_const};
+		event_with_invalid_integer["integer_const"] = 99;  // instead of 42
+		try {
+			await eventValidator.validate(event_with_invalid_integer);
+			assert(false, "ValidationError should have been thrown");
+		} catch (err) {
+			assert(err instanceof ValidationError);
+		}
+	});
+
+	it('should fail validation on const string with different type', async() => {
+		var event_with_string_int = {...testEvent_with_const};
+		event_with_string_int["string_const"] = 51;  // instead of string "hellow world"
+		try {
+			await eventValidator.validate(event_with_string_int);
+			assert(false, "ValidationError should have been thrown");
+		} catch (err) {
+			assert(err instanceof ValidationError);
+		}
+	});
+
+	it('should fail validation on const integer with wrong value', async() => {
+		var event_with_int_string = {...testEvent_with_const};
+		event_with_int_string["integer_const"] = "forty-two";  // instead of integer 42
+		try {
+			await eventValidator.validate(event_with_int_string);
+			assert(false, "ValidationError should have been thrown");
+		} catch (err) {
+			assert(err instanceof ValidationError);
+		}
+	});
 
 });

--- a/test/schemas/test_const/0.0.1
+++ b/test/schemas/test_const/0.0.1
@@ -1,0 +1,38 @@
+title: test_const
+description: Schema used for testing const
+$schema: http://json-schema.org/draft-07/schema#
+$id: /test_const/0.0.1
+type: object
+properties:
+  # global event fields
+  $schema:
+    type: string
+    description: >
+      The URI identifying the jsonschema for this event. This may be just
+      a short uri containing only the name and revision at the end of the
+      URI path.  e.g. /schema_name/12345 is acceptable. This often will
+      (and should) match the schema's $id field.
+  meta:
+    type: object
+    properties:
+      stream:
+        type: string
+        description: the stream name this message should be produced to.
+      id:
+        type: string
+        pattern: '^[a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}$'
+        maxLength: 36
+        description: the unique ID of this event; should match the dt field
+      dt:
+        type: string
+        format: date-time
+        maxLength: 26
+        description: the time stamp of the event, in ISO8601 format
+    required:
+      - stream
+      - id
+  # event-specific fields
+  integer_const:
+    const: 42
+  string_const:
+    const: "hello world"


### PR DESCRIPTION
A constant is a syntastic sugar for an enum having a single item.
However the spec does not mention anything regarding the expected type.

I am assuming validation is done with a strict equality and there is
thus no need to explicitly set the type. After all if one expects
integer value 42, there is no need to first validate the type then the
value.

Thus if one has a schema with:
```json
  {
    "type": "object",
      "properties": {
        "kind": {
          "const": "hello"
        },
        "val": {
          "const": 3,
        }
      }
  }
```
Then `kind` must be exactly the string "hello" and `val` must be the
integer 3 and there is no need to specify the type.

I asked for potential clarification of the spec:
https://github.com/json-schema-org/json-schema-spec/issues/1256

Which got an answer from Henry Andrews (one of the json schema spec
author):

> Each keyword operates independently unless the specification
> explicitly describes an interaction.
>
> const requires the exact value, so it's not possible to match the
> value and not match the type. But that doesn't meant that there's an
> implicit type keyword, or that type needs to be explicitly present.