### PR TITLE
Remove unsupported Content-Type application/x-www-form-urlencoded

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,8 +140,6 @@ function initApp(options) {
     // see https://www.w3.org/TR/reporting/#media-type
     app.use(bodyParser.json({ limit: app.conf.max_body_size || '100kb', type: ['application/json', 'text/plain', 'application/reports+json']  }));
     // --- END EventGate modification ---
-    // use the application/x-www-form-urlencoded parser
-    app.use(bodyParser.urlencoded({ extended: true }));
 
     return BBPromise.resolve(app);
 

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -52,6 +52,18 @@ describe('express app', function () {
         });
     });
 
+    it('should return 400 when given Content-Type application/x-www-form-urlencoded', () => {
+        return preq.post({
+            uri: `${server.config.uri}v1/events`,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: '{"foo": "bar"}'
+        }).catch((res) => {
+            assert.deepEqual(res.status, 400);
+        });
+    });
+
     // it('should get static content gzipped', () => {
     //     return preq.get({
     //         uri: `${server.config.uri}static/index.html`,


### PR DESCRIPTION
When given the content type `application/x-www-form-urlencoded` with a JSON body, the body is parsed into an object with a single property with the key being the entire JSON string and the value being an empty string. This then makes it into EventGate which throws a misleading (but technically correct) error `Field(s) meta.stream were missing from event and could not be extracted` because of the malformed object.

I can't tell why the content type is allowed in the first place; the only explanation I can see is that it's just a default from using service-template-node. And since the README states that the service only listens to `application/json` anyways, I thought it would be better to just remove the body parsing instead of handling this edge case.

Bug: [T313202](https://phabricator.wikimedia.org/T313202)